### PR TITLE
Add settings (haptic) demonstration on watch app

### DIFF
--- a/targetZoneKeeper Watch App/ContentView.swift
+++ b/targetZoneKeeper Watch App/ContentView.swift
@@ -15,7 +15,7 @@ enum Views {
 
 struct ContentView: View {
     @ObservedObject var heartRateController: HeartRateController
-    @ObservedObject var settingsDemonstrationModel: SettingsDemonstrationProvider
+    @ObservedObject var settingsDemonstrationProvider: SettingsDemonstrationProvider
 
     @State var currentView: Views = .welcome
     
@@ -29,6 +29,15 @@ struct ContentView: View {
         switch currentView {
         case .welcome:
             if !heartRateController.isWorkoutStarted {
+                if settingsDemonstrationProvider.isDemoRunning {
+                    Text("\(settingsDemonstrationProvider.hapticName)\n")
+                        .onChange(of: settingsDemonstrationProvider.haptic, initial: true) {
+                            WKInterfaceDevice.current().play(settingsDemonstrationProvider.haptic)
+                        }
+                    Button("Try") {
+                        WKInterfaceDevice.current().play(settingsDemonstrationProvider.haptic)
+                    }
+                } else {
                     VStack {
                         Picker("", selection: $heartRateController.settings.heartRateZone.value) {
                             ForEach(HeartRateZone.allCases) { value in
@@ -49,6 +58,7 @@ struct ContentView: View {
                         }
                     }
                     .padding()
+                }
             } else {
                 StartingWorkoutView()
                     .onAppear(perform: {currentView = .main})
@@ -129,5 +139,5 @@ struct StartingWorkoutView: View {
 }
 
 #Preview {
-    ContentView(heartRateController: HeartRateController(), settingsDemonstrationModel: SettingsDemonstrationProvider())
+    ContentView(heartRateController: HeartRateController(), settingsDemonstrationProvider: SettingsDemonstrationProvider())
 }

--- a/targetZoneKeeper Watch App/SettingsDemonstrationProvider.swift
+++ b/targetZoneKeeper Watch App/SettingsDemonstrationProvider.swift
@@ -10,12 +10,12 @@ import WatchKit
 
 class SettingsDemonstrationProvider: ObservableObject {
 
-    @Published var isHapticsListOpen: Bool = false
+    @Published var isDemoRunning: Bool = false
+
+    @Published var haptic: WKHapticType = .success
+    @Published var hapticName: String = ""
 
     var phoneData = ConnectionProviderWatch.shared
-
-    @Published var currentHaptic: WKHapticType = .success
-    @Published var currentHapticName: String = ""
 
     init() {
         phoneData.settingsDemonstration = self

--- a/targetZoneKeeper Watch App/targetZoneKeeperApp.swift
+++ b/targetZoneKeeper Watch App/targetZoneKeeperApp.swift
@@ -10,11 +10,11 @@ import SwiftUI
 @main
 struct targetZoneKeeper_Watch_AppApp: App {
     @StateObject var heartRateData: HeartRateController = HeartRateController()
-    @StateObject var settingsDemonstrationData: SettingsDemonstrationProvider = SettingsDemonstrationProvider()
+    @StateObject var settingsDemonstration: SettingsDemonstrationProvider = SettingsDemonstrationProvider()
     
     var body: some Scene {
         WindowGroup {
-            ContentView(heartRateController: heartRateData, settingsDemonstrationModel: settingsDemonstrationData)
+            ContentView(heartRateController: heartRateData, settingsDemonstrationProvider: settingsDemonstration)
         }
     }
 }

--- a/targetZoneKeeper/ConnectionProviderPhone.swift
+++ b/targetZoneKeeper/ConnectionProviderPhone.swift
@@ -68,9 +68,8 @@ class ConnectionProviderPhone: NSObject, WCSessionDelegate, ObservableObject {
         print("ConnectionProviderPhone - init(). Session reachable: \(self.mySession.isReachable)")
     }
 
-    func sendStartWorkout() {
-        mySession.transferUserInfo(["workoutIsStarted": true])
-        print("ConnectionProviderPhone - sendStartWorkout(). Session is activated: \(mySession.activationState == WCSessionActivationState.activated). Session reachable: \(mySession.isReachable)")
+    func checkSessionStatus() {
+        print("ConnectionProviderPhone. Session is activated: \(mySession.activationState == WCSessionActivationState.activated). Session reachable: \(mySession.isReachable)")
         Task { @MainActor in
             if mySession.activationState == WCSessionActivationState.activated {
                 print("The WCSession is active, starting transfer")
@@ -79,27 +78,31 @@ class ConnectionProviderPhone: NSObject, WCSessionDelegate, ObservableObject {
             }
         }
     }
-    
+
+    func sendStartWorkout() {
+        mySession.transferUserInfo(["workoutIsStarted": true])
+        checkSessionStatus()
+    }
+
+    func sendHapticDemo(active: Bool, haptic: Haptics? = nil) {
+        let jsonEncoder = JSONEncoder()
+        do {
+            let hapticData = try jsonEncoder.encode(haptic)
+            mySession.transferUserInfo(["hapticDemo": ["hapticDemoIsRunning": active, "haptic": hapticData]])
+            checkSessionStatus()
+        } catch {
+            print("sendHapticDemo: error encoding json: \(error)")
+        }
+    }
+
     func sendSettingsToWatch(settings: Settings) {
         let jsonEncoder = JSONEncoder()
         do {
             let data = try jsonEncoder.encode(settings)
             mySession.transferUserInfo(["settings": data])
-
-            print("ConnectionProviderPhone - sendSettingsToWatch(). Session is activated: \(mySession.activationState == WCSessionActivationState.activated). Session reachable: \(mySession.isReachable)")
-
-            Task { @MainActor in
-                if mySession.activationState == WCSessionActivationState.activated {
-                    print("The WCSession is active, starting transfer")
-                } else {
-                    print("The WCSession is not activated or is not reachable")
-                }
-            }
+            checkSessionStatus()
         } catch {
             print("sendSettings: error encoding json: \(error)")
         }
-    }
-
-    func sendHapticTestToWatch(haptic: Haptics) {
     }
 }

--- a/targetZoneKeeper/ContentView.swift
+++ b/targetZoneKeeper/ContentView.swift
@@ -76,8 +76,9 @@ struct ContentView: View {
                         destination: HapticTypesView(
                             zoneAlert: $settingsLoader.settings.fasterHaptic.value,
                             onSelect: {
-                                ConnectionProviderPhone.shared.sendHapticTestToWatch(haptic: settingsLoader.settings.fasterHaptic.value)
+                                ConnectionProviderPhone.shared.sendHapticDemo(active: true, haptic: settingsLoader.settings.fasterHaptic.value)
                             }, onListDisappear: {
+                                ConnectionProviderPhone.shared.sendHapticDemo(active: false)
                                 settingsLoader.settings.fasterHaptic.updateTime()
                                 sendToWatchAndSave()
                             }
@@ -95,8 +96,9 @@ struct ContentView: View {
                         destination: HapticTypesView(
                             zoneAlert: $settingsLoader.settings.inZoneHaptic.value,
                             onSelect: {
-                                ConnectionProviderPhone.shared.sendHapticTestToWatch(haptic: settingsLoader.settings.inZoneHaptic.value)
+                                ConnectionProviderPhone.shared.sendHapticDemo(active: true, haptic: settingsLoader.settings.inZoneHaptic.value)
                             }, onListDisappear: {
+                                ConnectionProviderPhone.shared.sendHapticDemo(active: false)
                                 settingsLoader.settings.inZoneHaptic.updateTime()
                                 sendToWatchAndSave()
                             }
@@ -113,8 +115,9 @@ struct ContentView: View {
                         destination: HapticTypesView(
                             zoneAlert: $settingsLoader.settings.slowerHaptic.value,
                             onSelect: {
-                                ConnectionProviderPhone.shared.sendHapticTestToWatch(haptic: settingsLoader.settings.slowerHaptic.value)
+                                ConnectionProviderPhone.shared.sendHapticDemo(active: true, haptic: settingsLoader.settings.slowerHaptic.value)
                             }, onListDisappear: {
+                                ConnectionProviderPhone.shared.sendHapticDemo(active: false)
                                 settingsLoader.settings.slowerHaptic.updateTime()
                                 sendToWatchAndSave()
                             }


### PR DESCRIPTION
Add settings (haptic) demonstration to the watch app.
When user opens a haptic list in Settings and selects a haptic for alerts in the phone app, the selected haptic is played in the watch app (the demonstration view appears). User has an ability to play a haptic again (with a button). 
When user closes the haptic list on phone app, the demonstration view  disappears.
![incoming-780E85FE-EE50-434E-951A-C801E82F7EF0](https://github.com/mbliznikova/Target-Zone-Keeper/assets/7782090/259a835b-5090-4230-bf93-98413276bd80)
